### PR TITLE
[INFRA]: Remove title prefixes from issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-hotfix.yml
+++ b/.github/ISSUE_TEMPLATE/01-hotfix.yml
@@ -1,6 +1,5 @@
 name: 🔥 Hot-Fix
 description: Critical issue requiring immediate attention
-title: "[HOTFIX]: "
 labels: ["priority: critical"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/02-bug.yml
+++ b/.github/ISSUE_TEMPLATE/02-bug.yml
@@ -1,6 +1,5 @@
 name: 🐞 Bug
 description: Report an unexpected problem or behavior
-title: "[BUG]: "
 labels: ["bug"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/03-feature.yml
+++ b/.github/ISSUE_TEMPLATE/03-feature.yml
@@ -1,6 +1,5 @@
 name: ✨ Feature
 description: Suggest a new feature or enhancement
-title: "[FEATURE]: "
 labels: ["feature"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/04-documentation.yml
+++ b/.github/ISSUE_TEMPLATE/04-documentation.yml
@@ -1,6 +1,5 @@
 name: 📚 Documentation
 description: Suggest improvements to documentation
-title: "[DOCS]: "
 labels: ["documentation"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/05-design.yml
+++ b/.github/ISSUE_TEMPLATE/05-design.yml
@@ -1,6 +1,5 @@
 name: 🎨 Design
 description: Suggest changes to UI/UX or visual elements
-title: "[DESIGN]: "
 labels: ["design"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/06-infrastructure.yml
+++ b/.github/ISSUE_TEMPLATE/06-infrastructure.yml
@@ -1,6 +1,5 @@
 name: 🔧 Infrastructure
 description: Suggest improvements to development processes or tooling
-title: "[INFRA]: "
 labels: ["infrastructure"]
 body:
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/07-refactor.yml
+++ b/.github/ISSUE_TEMPLATE/07-refactor.yml
@@ -1,6 +1,5 @@
 name: ♻️ Refactor
 description: Suggest code quality improvements without changing functionality
-title: "[REFACTOR]: "
 labels: ["refactor"]
 body:
   - type: markdown


### PR DESCRIPTION
# Remove title prefixes from issue templates

## Description
Removes the type prefix from issue titles since the type is assigned as a separate attribute.