### PR TITLE
Fix discord links

### DIFF
--- a/src/components/features/about/ContactSection.tsx
+++ b/src/components/features/about/ContactSection.tsx
@@ -15,7 +15,7 @@ export function ContactSection() {
           title={t('about.socialsCard.card1.title')}
           badgeName='discord-plural'
           description={t('about.socialsCard.card1.description')}
-          link='https://discord.gg/WSJUCWZD'
+          link='https://discord.gg/kDa8YC8u5J'
         />
 
         <ContactCard

--- a/src/components/features/settings/addon-verification/steps/CurseForgeStep.tsx
+++ b/src/components/features/settings/addon-verification/steps/CurseForgeStep.tsx
@@ -26,7 +26,7 @@ export default function CurseForgeStep({ next, back }: StepProps) {
           <li>
             Get verified manually on our{' '}
             <a
-              href='https://discord.gg/AvAWFU5rhB'
+              href='https://discord.gg/kDa8YC8u5J'
               className='text-primary hover:underline'
               target='_blank'
               rel='noopener noreferrer'


### PR DESCRIPTION
Fixed 2 lines of code that were returning the wrong discord link

## Testing
- [x] click the link
- [x] open the link
- [x] profit

## Related Issues
#293 this was fixed 