### PR TITLE
Refactor: Update Schematics API Hooks with Typed Documents

### DIFF
--- a/src/api/endpoints/useFeatureFlags.tsx
+++ b/src/api/endpoints/useFeatureFlags.tsx
@@ -43,7 +43,6 @@ export async function fetchFeatureFlag(userId: string, flagKey: string): Promise
 
     if (response.total === 0) return false;
 
-    // Now TypeScript knows all the properties in our FeatureFlag
     const feature: FeatureFlag = response.documents[0];
 
     return evaluateFlag(feature, userId);

--- a/src/api/endpoints/useSchematics.tsx
+++ b/src/api/endpoints/useSchematics.tsx
@@ -23,10 +23,11 @@ const COLLECTION_ID = '67b2310d00356b0cb53c';
 /**
  * Query hook to fetch a single schematic by its ID.
  */
-export const useFetchSchematic = (id: string) => {
+export const useFetchSchematic = (id?: string) => {
   return useQuery<Schematic | null>({
     queryKey: ['schematics', id],
     queryFn: async () => {
+      if (!id) return null;
       try {
         const response = await databases.getDocument<Schematic>(DATABASE_ID, COLLECTION_ID, id);
 

--- a/src/api/endpoints/useSearchSchematics.tsx
+++ b/src/api/endpoints/useSearchSchematics.tsx
@@ -19,7 +19,7 @@ export const useSearchSchematics = ({
   if (query === '') {
     query = '*';
   }
-  // Define filter logic for category, version, and loaders
+
   const filter = (): string => {
     const filters: string[] = [];
     const addFilter = (field: string, value: string) => {
@@ -38,6 +38,7 @@ export const useSearchSchematics = ({
 
     return filters.length > 0 ? filters.join(' AND ') : '';
   };
+
   const queryResult = useQuery({
     queryKey: [
       'searchSchematics',
@@ -52,19 +53,13 @@ export const useSearchSchematics = ({
     ],
     queryFn: async () => {
       const index = searchClient.index('schematics');
-      // Fetch raw results from Meilisearch with proper typing
       const result = (await index.search(query, {
         limit: 20,
         offset: (page - 1) * 20,
         filter: filter(),
       })) as MeiliSchematicResponse;
 
-      // Access the hits with proper typing
       const hits: MeiliSchematicHits = result.hits;
-
-      // Since Meilisearch already returns data in the Appwrite format,
-      // we can use the hits directly as Schematics with minimal transformation
-      // Convert to Schematic array, ensuring type safety without explicit 'any'
       const schematics: Schematic[] = Array.isArray(hits) ? hits : [];
 
       return {
@@ -78,9 +73,7 @@ export const useSearchSchematics = ({
 
   const { data, isLoading, isError, error, isFetching } = queryResult;
 
-  // `data` is now an array of Schematic objects
   const schematics = data?.data ?? [];
-
   const totalHits = data?.totalHits ?? 0;
   const hasNextPage = (page - 1) * 20 + schematics.length < totalHits;
   const hasPreviousPage = page > 1;

--- a/src/schemas/schematic.schema.tsx
+++ b/src/schemas/schematic.schema.tsx
@@ -59,7 +59,7 @@ export const updateSchematicSchema = z.object({
   create_versions: z.array(z.string()).optional(),
   modloaders: z.array(z.string()).optional(),
   categories: z.array(z.string()).min(1, 'At least one category is required').optional(),
-  sub_categories: z.array(z.string()).optional().optional(),
+  sub_categories: z.array(z.string()).optional(),
   slug: z.string().optional(),
   status: z.enum(['draft', 'published', 'archived']).default('published').optional(),
 });

--- a/src/schemas/schematic.schema.tsx
+++ b/src/schemas/schematic.schema.tsx
@@ -30,9 +30,8 @@ export const searchSchematicsPropsSchema = z.object({
   id: z.string().optional(),
 });
 
-// Database schema for stored schematics
-export const schematicSchema = z.object({
-  $id: z.string(),
+// For creating a new schematic (omit ID and other auto-generated fields)
+export const createSchematicSchema = z.object({
   title: z.string().min(1, 'Title is required'),
   description: z.string(),
   schematic_url: z.string().url('Must be a valid URL'),
@@ -45,28 +44,28 @@ export const schematicSchema = z.object({
   categories: z.array(z.string()).min(1, 'At least one category is required'),
   sub_categories: z.array(z.string()).optional(),
   slug: z.string(),
-  downloads: z.number().int().nonnegative().default(0),
   status: z.enum(['draft', 'published', 'archived']).default('published'),
-  $createdAt: z.string().datetime(),
-  $updatedAt: z.string().datetime(),
-  likes: z.number().int().nonnegative().default(0),
 });
 
-// For retrieving a schematic with optional fields
-export const partialSchematicSchema = schematicSchema.partial();
-
-// For creating a new schematic (omit ID and other auto-generated fields)
-export const createSchematicSchema = schematicSchema.omit({
-  $id: true,
-  downloads: true,
-  $createdAt: true,
-  $updatedAt: true,
-  likes: true, // Omit likes for creation schema
+// For updating a schematic
+export const updateSchematicSchema = z.object({
+  title: z.string().min(1, 'Title is required').optional(),
+  description: z.string().optional(),
+  schematic_url: z.string().url('Must be a valid URL').optional(),
+  image_urls: z.array(z.string().url('Must be a valid URL')).optional(),
+  user_id: z.string().optional(),
+  authors: z.array(z.string()).optional(),
+  game_versions: z.array(z.string()).optional(),
+  create_versions: z.array(z.string()).optional(),
+  modloaders: z.array(z.string()).optional(),
+  categories: z.array(z.string()).min(1, 'At least one category is required').optional(),
+  sub_categories: z.array(z.string()).optional().optional(),
+  slug: z.string().optional(),
+  status: z.enum(['draft', 'published', 'archived']).default('published').optional(),
 });
 
 // Schema for search results
 export const searchSchematicsResultSchema = z.object({
-  data: z.array(schematicSchema),
   isLoading: z.boolean(),
   isError: z.boolean(),
   error: z.instanceof(Error).nullable(),

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,15 @@
 // src/types/index.ts
 import type { z } from 'zod';
 
-export type { User, UserPreferences, BetaTesterPrefs, FeatureFlag } from '@/types/appwrite';
+import type { Schematic } from '@/types/appwrite';
+
+export type {
+  User,
+  UserPreferences,
+  BetaTesterPrefs,
+  FeatureFlag,
+  Schematic,
+} from '@/types/appwrite';
 
 import type {
   AddonSchema,
@@ -57,19 +65,23 @@ export type SearchBlogResult = z.infer<typeof SearchBlogResultSchema>;
 
 import type {
   createSchematicSchema,
-  partialSchematicSchema,
   schematicFormSchema,
-  schematicSchema,
   searchSchematicsPropsSchema,
-  searchSchematicsResultSchema,
 } from '@/schemas/schematic.schema';
 
 export type SearchSchematicsProps = z.infer<typeof searchSchematicsPropsSchema>;
 export type SchematicFormValues = z.infer<typeof schematicFormSchema>;
-export type Schematic = z.infer<typeof schematicSchema>;
-export type PartialSchematic = z.infer<typeof partialSchematicSchema>;
 export type CreateSchematic = z.infer<typeof createSchematicSchema>;
-export type SearchSchematicsResult = z.infer<typeof searchSchematicsResultSchema>;
+export type SearchSchematicsResult = Pick<
+  UseQueryResult<unknown>,
+  'isLoading' | 'isError' | 'error' | 'isFetching'
+> & {
+  data: Schematic[]; // Use the canonical Schematic type here
+  hasNextPage: boolean;
+  hasPreviousPage: boolean;
+  totalHits: number;
+  page: number;
+};
 
 import type {
   CreateFeatureFlagSchema,
@@ -98,5 +110,9 @@ import type { AdminLogsSchema } from '@/schemas/adminLogs.schema.tsx';
 export type AdminLogs = z.infer<typeof AdminLogsSchema>;
 
 import type { OAuthProvidersSchema } from '@/schemas/OAuthProviders.schema.tsx';
+// Import UseQueryResult explicitly at the top
+import type { UseQueryResult } from '@tanstack/react-query';
+
+// Remove redundant import since we already have export type { Schematic } above
 
 export type OAuthProvidersType = z.infer<typeof OAuthProvidersSchema>;

--- a/src/types/meilisearch.ts
+++ b/src/types/meilisearch.ts
@@ -1,0 +1,24 @@
+// Note: If 'meilisearch' package doesn't directly export these types,
+// you may need to use '@meilisearch/instant-meilisearch' or define your own
+import type { Hit, SearchResponse } from 'meilisearch';
+
+// Define Hits type if it's not directly available from the library
+type Hits<T> = Array<Hit<T>>;
+import type { Schematic } from '@/types/appwrite';
+
+/**
+ * Types for Meilisearch responses and hits
+ *
+ * These types provide proper typing for Meilisearch-specific structures
+ * while leveraging our canonical Appwrite document types.
+ */
+
+// Type for a full Meilisearch search response with Schematic data
+export type MeiliSchematicResponse = SearchResponse<Schematic>;
+
+// Type for an array of Meilisearch hits with Schematic data
+// This includes Meilisearch-specific properties like _matchesPosition
+export type MeiliSchematicHits = Hits<Schematic>;
+
+// Type for a single Meilisearch hit with Schematic data
+export type MeiliSchematicHit = MeiliSchematicHits[number];

--- a/src/types/meilisearch.ts
+++ b/src/types/meilisearch.ts
@@ -1,9 +1,4 @@
-// Note: If 'meilisearch' package doesn't directly export these types,
-// you may need to use '@meilisearch/instant-meilisearch' or define your own
-import type { Hit, SearchResponse } from 'meilisearch';
-
-// Define Hits type if it's not directly available from the library
-type Hits<T> = Array<Hit<T>>;
+import type { Hits, SearchResponse } from 'meilisearch';
 import type { Schematic } from '@/types/appwrite';
 
 /**
@@ -15,10 +10,5 @@ import type { Schematic } from '@/types/appwrite';
 
 // Type for a full Meilisearch search response with Schematic data
 export type MeiliSchematicResponse = SearchResponse<Schematic>;
-
-// Type for an array of Meilisearch hits with Schematic data
-// This includes Meilisearch-specific properties like _matchesPosition
 export type MeiliSchematicHits = Hits<Schematic>;
-
-// Type for a single Meilisearch hit with Schematic data
 export type MeiliSchematicHit = MeiliSchematicHits[number];


### PR DESCRIPTION
## Description
This PR updates our schematics API hooks to use the new Appwrite-typed Schematic model, creating a more type-safe and consistent approach to handle data from both Appwrite and Meilisearch.

Key improvements:
- Added Meilisearch type definitions that properly integrate with our Appwrite document models
- Refactored useSchematics hooks to use typed generics like `getDocument<Schematic>()` for better type safety
- Fixed React hooks implementation to follow Rules of Hooks (moved try/catch inside queryFn)
- Removed redundant mapping code by leveraging TypeScript generics
- Added MeiliSchematic types to handle search responses while maintaining consistent types
- Updated schema definitions to focus on validation rather than type definitions

## Testing
- Verified all schematics APIs use the Schematic type from `@/types/appwrite`
- Confirmed search functionality works with the new type integration
- Tested error handling in the hooks to ensure proper fallbacks

## Related Issues
Fixes #317
Depends on #315
Part of epic #314

## Additional Notes
This PR implements a hybrid approach where:
1. TypeScript interfaces extending `Models.Document` provide the canonical data model
2. Zod schemas are still used for form validation and API input contracts
3. API hooks use generics for type-safe data fetching
4. Meilisearch results are properly typed with the same canonical types

Future work should apply this same pattern to Addons and Blogs collections.