### PR TITLE
refactor: Migrate Addon types to use Appwrite document models

### DIFF
--- a/src/api/endpoints/useAddons.tsx
+++ b/src/api/endpoints/useAddons.tsx
@@ -2,140 +2,131 @@ import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/hooks/useToast';
 import { databases } from '@/config/appwrite';
 import { Query } from 'appwrite';
-import type { Addon } from '@/types';
+import type { Addon } from '@/types/appwrite';
+import type { AddonWithParsedFields } from '@/types/addons/addon-details';
+import type { CurseForgeRawObject } from '@/types/addons/curseforge';
+import type { ModrinthRawObject } from '@/types/addons/modrinth';
 
 const DATABASE_ID = '67b1dc430020b4fb23e3';
 const COLLECTION_ID = '67b1dc4b000762a0ccc6';
 
-function tryParseJson(jsonString: string) {
+/**
+ * Helper function to parse JSON strings from Appwrite
+ * Used for fields stored as JSON strings like curseforge_raw and modrinth_raw
+ */
+function parseJsonField<T>(jsonString: string | null): T | null {
+  if (!jsonString) return null;
   try {
-    const parsed = JSON.parse(jsonString);
-    return parsed;
+    return JSON.parse(jsonString) as T;
   } catch (e) {
     console.error('Failed to parse JSON', e);
-    return undefined;
+    return null;
   }
 }
 
+/**
+ * Adds parsed JSON fields to an Addon object
+ */
+function addParsedFields(addon: Addon): AddonWithParsedFields {
+  const addonWithParsed: AddonWithParsedFields = { ...addon };
+
+  if (addon.curseforge_raw) {
+    addonWithParsed.curseforge_raw_parsed = parseJsonField<CurseForgeRawObject>(
+      addon.curseforge_raw
+    );
+  }
+
+  if (addon.modrinth_raw) {
+    addonWithParsed.modrinth_raw_parsed = parseJsonField<ModrinthRawObject>(addon.modrinth_raw);
+  }
+
+  return addonWithParsed;
+}
+
+/**
+ * Hook to fetch a single addon by ID
+ * @param id The ID of the addon to fetch
+ * @returns Query result with the addon data
+ */
 export const useFetchAddon = (id?: string) => {
-  return useQuery<Addon | null>({
+  return useQuery<AddonWithParsedFields | null>({
     queryKey: ['addon', id],
     queryFn: async () => {
       if (!id) return null;
 
-      const response = await databases.getDocument(DATABASE_ID, COLLECTION_ID, id);
+      try {
+        // Using type parameter with getDocument for automatic type conversion
+        const addon = await databases.getDocument<Addon>(DATABASE_ID, COLLECTION_ID, id);
 
-      const addonData: Addon = {
-        $id: response.$id,
-        name: response.name || '',
-        downloads: response.downloads || '',
-        description: response.description || '',
-        slug: response.slug || '',
-        author: response.author || '',
-        categories: Array.isArray(response.categories) ? response.categories : [],
-        icon: response.icon || '',
-        created_at: response.created_at,
-        updated_at: response.updated_at,
-        curseforge_raw: response.curseforge_raw ? tryParseJson(response.curseforge_raw) : undefined,
-        modrinth_raw: response.modrinth_raw ? tryParseJson(response.modrinth_raw) : undefined,
-        sources: Array.isArray(response.sources) ? response.sources : [],
-        loaders: Array.isArray(response.loaders) ? response.loaders : [],
-        isValid: response.isValid || false,
-        isChecked: response.isChecked || false,
-        minecraft_versions: Array.isArray(response.minecraft_versions)
-          ? response.minecraft_versions
-          : [],
-        create_versions: Array.isArray(response.create_versions) ? response.create_versions : [],
-        claimed_by: response.claimed_by || '',
-      };
-
-      return addonData;
+        // Add the parsed fields to the addon object
+        return addParsedFields(addon);
+      } catch (error) {
+        console.error('Error fetching addon:', error);
+        throw error;
+      }
     },
     enabled: Boolean(id),
-    staleTime: 1000 * 60 * 5,
+    staleTime: 1000 * 60 * 5, // 5 minutes
     retry: false,
   });
 };
 
+/**
+ * Hook to fetch a single addon by slug
+ * @param slug The slug of the addon to fetch
+ * @returns Query result with the addon data
+ */
 export const useFetchAddonBySlug = (slug?: string) => {
-  return useQuery<Addon | null>({
-    queryKey: ['addon', slug],
+  return useQuery<AddonWithParsedFields | null>({
+    queryKey: ['addon', 'slug', slug],
     queryFn: async () => {
       if (!slug) return null;
 
-      const response = await databases.listDocuments(DATABASE_ID, COLLECTION_ID, [
-        Query.equal('slug', slug),
-      ]);
+      try {
+        const response = await databases.listDocuments<Addon>(DATABASE_ID, COLLECTION_ID, [
+          Query.equal('slug', slug),
+        ]);
 
-      if (response.documents.length === 0) return null;
+        if (response.documents.length === 0) return null;
 
-      const doc = response.documents[0];
-      const addonData: Addon = {
-        $id: doc.$id,
-        name: doc.name || '',
-        downloads: doc.downloads || '',
-        description: doc.description || '',
-        slug: doc.slug || '',
-        author: doc.author || '',
-        categories: Array.isArray(doc.categories) ? doc.categories : [],
-        icon: doc.icon || '',
-        created_at: doc.created_at,
-        updated_at: doc.updated_at,
-        curseforge_raw: doc.curseforge_raw ? tryParseJson(doc.curseforge_raw) : undefined,
-        modrinth_raw: doc.modrinth_raw ? tryParseJson(doc.modrinth_raw) : undefined,
-        sources: Array.isArray(doc.sources) ? doc.sources : [],
-        loaders: Array.isArray(doc.loaders) ? doc.loaders : [],
-        isValid: doc.isValid || false,
-        isChecked: doc.isChecked || false,
-        minecraft_versions: Array.isArray(doc.minecraft_versions) ? doc.minecraft_versions : [],
-        create_versions: Array.isArray(doc.create_versions) ? doc.create_versions : [],
-        claimed_by: doc.claimed_by || '',
-      };
+        const addon = response.documents[0];
 
-      return addonData;
+        // Add the parsed fields to the addon object
+        return addParsedFields(addon);
+      } catch (error) {
+        console.error('Error fetching addon by slug:', error);
+        throw error;
+      }
     },
     enabled: Boolean(slug),
-    staleTime: 1000 * 60 * 5,
+    staleTime: 1000 * 60 * 5, // 5 minutes
     retry: false,
   });
 };
 
+/**
+ * Hook to fetch paginated addons
+ * @param page Current page number
+ * @param limit Number of items per page
+ * @returns Query result with addons and pagination data
+ */
 export const useFetchAddons = (page: number, limit: number = 10) => {
   return useQuery<{
-    addons: Addon[];
+    addons: AddonWithParsedFields[];
     total: number;
     hasNextPage: boolean;
     hasPreviousPage: boolean;
   }>({
-    queryKey: ['addons', page, limit],
+    queryKey: ['addons', 'list', page, limit],
     queryFn: async () => {
       try {
-        const response = await databases.listDocuments(DATABASE_ID, COLLECTION_ID, [
+        const response = await databases.listDocuments<Addon>(DATABASE_ID, COLLECTION_ID, [
           Query.limit(limit),
           Query.offset((page - 1) * limit),
         ]);
 
-        const addons: Addon[] = response.documents.map((doc) => ({
-          $id: doc.$id,
-          name: doc.name || '',
-          downloads: doc.downloads || '',
-          description: doc.description || '',
-          slug: doc.slug || '',
-          author: doc.author || '',
-          categories: Array.isArray(doc.categories) ? doc.categories : [],
-          icon: doc.icon || '',
-          created_at: doc.created_at,
-          updated_at: doc.updated_at,
-          curseforge_raw: doc.curseforge_raw ? tryParseJson(doc.curseforge_raw) : undefined,
-          modrinth_raw: doc.modrinth_raw ? tryParseJson(doc.modrinth_raw) : undefined,
-          sources: Array.isArray(doc.sources) ? doc.sources : [],
-          loaders: Array.isArray(doc.loaders) ? doc.loaders : [],
-          isValid: doc.isValid || false,
-          isChecked: doc.isChecked || false,
-          minecraft_versions: Array.isArray(doc.minecraft_versions) ? doc.minecraft_versions : [],
-          create_versions: Array.isArray(doc.create_versions) ? doc.create_versions : [],
-          claimed_by: doc.claimed_by || '',
-        }));
+        // Process JSON fields for each addon
+        const addons = response.documents.map((addon) => addParsedFields(addon));
 
         return {
           addons,
@@ -143,8 +134,8 @@ export const useFetchAddons = (page: number, limit: number = 10) => {
           hasNextPage: page * limit < response.total,
           hasPreviousPage: page > 1,
         };
-      } catch (err) {
-        console.error('Error fetching addons:', err);
+      } catch (error) {
+        console.error('Error fetching addons list:', error);
         throw new Error('Failed to fetch addons');
       }
     },
@@ -162,18 +153,42 @@ export const useUpdateAddon = () => {
   return useMutation({
     mutationFn: async ({ addonId, data }: { addonId: string; data: Partial<Addon> }) => {
       try {
-        return await databases.updateDocument(DATABASE_ID, COLLECTION_ID, addonId, data);
+        // Handle JSON fields that need to be stringified
+        const updateData = { ...data };
+
+        // If raw data is provided as an object, stringify it
+        if (updateData.curseforge_raw && typeof updateData.curseforge_raw === 'object') {
+          updateData.curseforge_raw = JSON.stringify(updateData.curseforge_raw);
+        }
+
+        if (updateData.modrinth_raw && typeof updateData.modrinth_raw === 'object') {
+          updateData.modrinth_raw = JSON.stringify(updateData.modrinth_raw);
+        }
+
+        return await databases.updateDocument<Addon>(
+          DATABASE_ID,
+          COLLECTION_ID,
+          addonId,
+          updateData
+        );
       } catch (error) {
         console.error('Error updating addon:', error);
         throw error;
       }
     },
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['addons'] });
+    onSuccess: (_, variables) => {
+      // Invalidate specific queries
+      queryClient.invalidateQueries({ queryKey: ['addon', variables.addonId] });
+      queryClient.invalidateQueries({ queryKey: ['addons', 'list'] });
+      queryClient.invalidateQueries({ queryKey: ['searchAddons'] });
     },
   });
 };
 
+/**
+ * Hook to delete an addon
+ * @returns Mutation function for deleting an addon
+ */
 export const useDeleteAddon = () => {
   const queryClient = useQueryClient();
 
@@ -192,12 +207,13 @@ export const useDeleteAddon = () => {
           title: '❌ Error deleting the addon ❌',
         });
         console.error('Error deleting addon:', error);
-
         throw error;
       }
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ['addons'] });
+      // Invalidate relevant queries
+      queryClient.invalidateQueries({ queryKey: ['addons', 'list'] });
+      queryClient.invalidateQueries({ queryKey: ['searchAddons'] });
     },
   });
 };

--- a/src/components/common/ScrollingAddonBackground.tsx
+++ b/src/components/common/ScrollingAddonBackground.tsx
@@ -43,14 +43,14 @@ export const ScrollingAddonBackground = ({
   const totalAddonHeight = addonHeight + addonMarginBottom;
 
   // API hook for fetching addon data with prefetch enabled
-  const { data: hits, isLoading: isLoadingAddons } = useSearchAddons(
+  const { data: hits, isLoading: isLoadingAddons } = useSearchAddons({
     query,
     page,
     category,
     version,
     loaders,
-    limit
-  );
+    limit,
+  });
 
   // Update addons when data is fetched
   useEffect(() => {

--- a/src/components/features/addons/AddonList.tsx
+++ b/src/components/features/addons/AddonList.tsx
@@ -25,7 +25,14 @@ const AddonsList = () => {
     isLoading,
     isFetching,
     hasNextPage,
-  } = useSearchAddons(query, page, category, version, loaders, ITEMS_PER_PAGE);
+  } = useSearchAddons({
+    query,
+    page,
+    category,
+    version,
+    loaders,
+    limit: ITEMS_PER_PAGE,
+  });
 
   // Use the useInfiniteScroll hook
   const { sentinelRef, loadingMore } = useInfiniteScroll({

--- a/src/components/features/dynamic-bg/DynamicBg.tsx
+++ b/src/components/features/dynamic-bg/DynamicBg.tsx
@@ -29,7 +29,14 @@ export const DynamicBg = ({
   const [containerHeight, setContainerHeight] = useState<number>(0);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  const { data: hits } = useSearchAddons(query, page, category, version, loaders, limit);
+  const { data: hits } = useSearchAddons({
+    query,
+    page,
+    category,
+    version,
+    loaders,
+    limit,
+  });
 
   useEffect(() => {
     if (hits && hits.length > 0) {

--- a/src/types/addons/addon-details.ts
+++ b/src/types/addons/addon-details.ts
@@ -1,6 +1,10 @@
 // src/types/addons/addon-details.ts
 import type { Addon } from '@/types';
-import type { CondensedModrinthProject, ModrinthRawObject, ModrinthVersionDependency } from './modrinth';
+import type {
+  CondensedModrinthProject,
+  ModrinthRawObject,
+  ModrinthVersionDependency,
+} from './modrinth';
 import type { CurseForgeRawObject } from './curseforge';
 import type { ReactNode } from 'react';
 
@@ -61,7 +65,7 @@ export interface DonationLink {
 /**
  * Integrated addon data with properly nested structure
  */
-export interface IntegratedAddonData extends Addon {
+export interface IntegratedAddonData extends Omit<Addon, 'claimed_by'> {
   curseforgeObject?: CurseForgeRawObject;
   modrinthObject?: ModrinthRawObject;
   modrinth: CondensedModrinthProject;
@@ -93,4 +97,20 @@ export interface AddonCompatibilityData {
       gameVersions?: string[];
     }[];
   };
+}
+
+/**
+ * Extended Addon type that includes parsed JSON fields
+ * This allows us to maintain type safety when working with parsed JSON data
+ */
+export interface AddonWithParsedFields extends Addon {
+  /**
+   * Parsed CurseForge data object
+   */
+  curseforge_raw_parsed?: CurseForgeRawObject | null;
+
+  /**
+   * Parsed Modrinth data object
+   */
+  modrinth_raw_parsed?: ModrinthRawObject | null;
 }

--- a/src/types/appwrite.ts
+++ b/src/types/appwrite.ts
@@ -26,6 +26,8 @@ export interface Addon extends Models.Document {
   categories: string[];
   downloads: number;
   icon: string;
+  created_at: string | null;
+  updated_at: string | null;
   curseforge_raw: string | null;
   modrinth_raw: string | null;
   sources: string[];

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,8 @@
 // src/types/index.ts
 import type { z } from 'zod';
-
+import type { UseQueryResult } from '@tanstack/react-query';
 import type { Schematic } from '@/types/appwrite';
+import type { AddonWithParsedFields } from '@/types/addons/addon-details';
 
 export type {
   User,
@@ -9,10 +10,12 @@ export type {
   BetaTesterPrefs,
   FeatureFlag,
   Schematic,
+  Addon,
 } from '@/types/appwrite';
 
+export type { AddonWithParsedFields } from '@/types/addons/addon-details';
+
 import type {
-  AddonSchema,
   ScreenshotSchema,
   LinksSchema,
   CategorySchema,
@@ -29,7 +32,6 @@ import type {
   LicenseSchema,
 } from '@/schemas/addon.schema';
 
-export type Addon = z.infer<typeof AddonSchema>;
 export type Screenshot = z.infer<typeof ScreenshotSchema>;
 export type Links = z.infer<typeof LinksSchema>;
 export type Category = z.infer<typeof CategorySchema>;
@@ -72,15 +74,28 @@ import type {
 export type SearchSchematicsProps = z.infer<typeof searchSchematicsPropsSchema>;
 export type SchematicFormValues = z.infer<typeof schematicFormSchema>;
 export type CreateSchematic = z.infer<typeof createSchematicSchema>;
+
 export type SearchSchematicsResult = Pick<
   UseQueryResult<unknown>,
   'isLoading' | 'isError' | 'error' | 'isFetching'
 > & {
-  data: Schematic[]; // Use the canonical Schematic type here
+  data: Schematic[];
   hasNextPage: boolean;
   hasPreviousPage: boolean;
   totalHits: number;
   page: number;
+};
+
+export type SearchAddonResult = Pick<
+  UseQueryResult<unknown>,
+  'isLoading' | 'isError' | 'error' | 'isFetching'
+> & {
+  data: AddonWithParsedFields[];
+  hasNextPage: boolean;
+  hasPreviousPage?: boolean;
+  totalHits: number;
+  page: number;
+  limit?: number;
 };
 
 import type {
@@ -106,13 +121,7 @@ export type GitHubRepo = z.infer<typeof GitHubRepoSchema>;
 export type GitHubContributorsResponse = z.infer<typeof GitHubContributorsResponseSchema>;
 
 import type { AdminLogsSchema } from '@/schemas/adminLogs.schema.tsx';
-
 export type AdminLogs = z.infer<typeof AdminLogsSchema>;
 
 import type { OAuthProvidersSchema } from '@/schemas/OAuthProviders.schema.tsx';
-// Import UseQueryResult explicitly at the top
-import type { UseQueryResult } from '@tanstack/react-query';
-
-// Remove redundant import since we already have export type { Schematic } above
-
 export type OAuthProvidersType = z.infer<typeof OAuthProvidersSchema>;

--- a/src/types/meilisearch.ts
+++ b/src/types/meilisearch.ts
@@ -1,14 +1,47 @@
 import type { Hits, SearchResponse } from 'meilisearch';
-import type { Schematic } from '@/types/appwrite';
+import type { Addon, Schematic, Blog } from '@/types/appwrite';
+import type { AddonWithParsedFields } from '@/types/addons/addon-details';
 
 /**
- * Types for Meilisearch responses and hits
+ * Type definitions for Meilisearch responses
  *
- * These types provide proper typing for Meilisearch-specific structures
- * while leveraging our canonical Appwrite document types.
+ * These types build on our canonical Appwrite document types
+ * to provide proper typing for search results.
  */
 
-// Type for a full Meilisearch search response with Schematic data
+// Addon search types
+export type MeiliAddonResponse = SearchResponse<Addon>;
+export type MeiliAddonHits = Hits<Addon>;
+export type MeiliAddonHit = MeiliAddonHits[number];
+
+// Schematic search types
 export type MeiliSchematicResponse = SearchResponse<Schematic>;
 export type MeiliSchematicHits = Hits<Schematic>;
 export type MeiliSchematicHit = MeiliSchematicHits[number];
+
+// Blog search types
+export type MeiliBlogResponse = SearchResponse<Blog>;
+export type MeiliBlogHits = Hits<Blog>;
+export type MeiliBlogHit = MeiliBlogHits[number];
+
+/**
+ * Utility type for search results that combines React Query's result
+ * with document-specific data
+ */
+export interface SearchResult<T> {
+  data: T[];
+  isLoading: boolean;
+  isError: boolean;
+  error: Error | null;
+  isFetching: boolean;
+  hasNextPage: boolean;
+  hasPreviousPage?: boolean;
+  totalHits: number;
+  page: number;
+  limit?: number;
+}
+
+// Use the extended addon type for search results
+export type SearchAddonResult = SearchResult<AddonWithParsedFields>;
+export type SearchSchematicResult = SearchResult<Schematic>;
+export type SearchBlogResult = SearchResult<Blog>;


### PR DESCRIPTION
# Type-Safe Addon Integration with Appwrite

## Overview
This PR migrates the Addon types to follow our new pattern of using Appwrite document models as the canonical types. It eliminates manual type mapping, improves type safety, and handles JSON fields consistently while maintaining backward compatibility.

## Changes
- Created `AddonWithParsedFields` interface for properly typed JSON fields
- Updated all API hooks in `useAddons.tsx` to use Appwrite's generic type parameters
- Refactored `useSearchAddons.tsx` to use object parameters instead of positional arguments
- Added a legacy function for backward compatibility with existing code
- Fixed all ESLint warnings related to `any` types
- Updated components using the search hooks to follow the new parameter pattern
- Fixed type conflicts in `IntegratedAddonData` interface

## Testing
- Verified all TypeScript and ESLint errors are resolved
- Confirmed addon search and display functionality works correctly
- Ensured JSON parsing is handled consistently

## Related Issues
Closes #318 

## Documentation
Added JSDoc comments throughout the code to explain the new approach and helper functions. The code follows the patterns established in our Appwrite Type Integration guide.