### PR TITLE
fix/deployement-and-fixes

### DIFF
--- a/src/components/features/addons/addon-details/AddonDetailsView.tsx
+++ b/src/components/features/addons/addon-details/AddonDetailsView.tsx
@@ -175,7 +175,9 @@ export const AddonDetailsView = ({ addon, createVersions = [] }: AddonDetailsVie
         </div>
 
         {/* Gallery with direct data access */}
-        <AddonDetailsGallery gallery={addon.modrinth.gallery} name={addon.name} />
+        {addon.modrinth.gallery.length > 0 ? (
+          <AddonDetailsGallery gallery={addon.modrinth.gallery} name={addon.name} />
+        ) : null}
 
         {/* Description */}
         {addon.modrinth.body && (

--- a/src/layouts/HeroLayout.tsx
+++ b/src/layouts/HeroLayout.tsx
@@ -49,7 +49,7 @@ export function HeroContent({
   const { isDarkMode } = useThemeStore();
 
   return (
-    <main className={cn('flex h-screen w-full flex-col justify-between', className)}>
+    <main className={cn('flex h-100 w-full flex-col justify-between', className)}>
       <div
         className={`flex-1 ${isDarkMode ? 'bg-shadow_steel_casing' : 'bg-refined_radiance_casing'}`}
       >

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,4 +1,6 @@
 // src/types/index.ts
+import type z from 'zod';
+
 export type {
   User,
   UserPreferences,
@@ -22,7 +24,6 @@ export type {
   VersionInfo,
   ExternalLink,
 } from '@/types/addons/addon-details';
-
 export type {
   EnvironmentCompatibilityProps,
   Dependencies,


### PR DESCRIPTION
## Description (required)

*   Removed fixed height (`h-screen`) from the `main` element in the `HeroContent` component to allow content to expand and enable scrolling when necessary.
* Added import of Zod into /src/types/index.ts for because of deployement issue 
## Testing

*   Verified that the footer is visible without scrolling when the content is short.
*   Verified that a scrollbar appears and the footer is accessible by scrolling when the content exceeds the viewport height.
*   Tested in both light and dark modes to ensure consistent behavior.

## Related Issues

*   Fixes: The footer was not visible when the content exceeded the screen height.

## Additional Notes

*   The `h-100` class was put on the main element.


