### PR TITLE
docs(links): Update links to new repo & site

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,8 @@ Browse the [full documentation](/docs/README.md) for more details.
 
 ```bash
 # Clone the repository
-git clone https://github.com/blueprint-site/blueprint-site.github.io.git
-cd blueprint-site.github.io
+git clone https://github.com/blueprint-site/blueprint-create.git
+cd blueprint-create
 
 # Install dependencies
 npm install
@@ -66,14 +66,14 @@ See our [installation guide](/docs/getting-started/installation.md) for detailed
 
 We welcome contributions from the community! Please read our [contributing guidelines](/docs/contributing/workflow.md) and [issue guidelines](/docs/contributing/issue-guidelines.md) to get started. We use GitHub issues and pull requests to manage our development workflow.
 
-- [Create a new issue](https://github.com/blueprint-site/blueprint-site.github.io/issues/new/choose)
-- [View current issues](https://github.com/blueprint-site/blueprint-site.github.io/issues)
+- [Create a new issue](https://github.com/blueprint-site/blueprint-create/issues/new/choose)
+- [View current issues](https://github.com/blueprint-site/blueprint-create/issues)
 
 ## Community
 
 - Join our [Discord Server](https://discord.gg/kDa8YC8u5J)
 - Follow us on [GitHub](https://github.com/blueprint-site)
-- Report issues [here](https://github.com/blueprint-site/blueprint-site.github.io/issues)
+- Report issues [here](https://github.com/blueprint-site/blueprint-create/issues)
 
 ## License
 
@@ -89,4 +89,4 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 - [Create Mod Team](https://github.com/Creators-of-Create/Create)
 - [Minecraft Modding Community](https://modrinth.com)
-- All our [contributors](https://github.com/blueprint-site/blueprint-site.github.io/graphs/contributors)
+- All our [contributors](https://github.com/blueprint-site/blueprint-create/graphs/contributors)

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ Blueprint is built with:
 
 - Join our [Discord Server](https://discord.gg/kDa8YC8u5J)
 - Follow us on [GitHub](https://github.com/blueprint-site)
-- Report issues [here](https://github.com/blueprint-site/blueprint-site.github.io/issues)
+- Report issues [here](https://github.com/blueprint-site/blueprint-create/issues)
 
 ## License
 

--- a/docs/contributing/getting-started.md
+++ b/docs/contributing/getting-started.md
@@ -21,14 +21,14 @@ Before you begin, make sure you have the following installed:
 2. Clone your fork to your local machine:
 
 ```bash
-git clone https://github.com/YOUR_USERNAME/blueprint-site.github.io.git
-cd blueprint-site.github.io
+git clone https://github.com/YOUR_USERNAME/blueprint-create.git
+cd blueprint-create
 ```
 
 3. Add the original repository as an upstream remote:
 
 ```bash
-git remote add upstream https://github.com/blueprint-site/blueprint-site.github.io.git
+git remote add upstream https://github.com/blueprint-site/blueprint-create.git
 ```
 
 ### 2. Install Dependencies
@@ -80,7 +80,7 @@ For a more detailed breakdown, see the [Blueprint Project Structure](../architec
 
 ### 1. Find an Issue
 
-1. Browse the [GitHub Issues](https://github.com/blueprint-site/blueprint-site.github.io/issues) for something you'd like to work on
+1. Browse the [GitHub Issues](https://github.com/blueprint-site/blueprint-create/issues) for something you'd like to work on
 2. Look for issues labeled `good first issue` if you're new to the project
 3. Comment on the issue to let others know you're working on it
 
@@ -155,9 +155,9 @@ git push origin feature/add-schematic-preview
 If you're stuck or have questions:
 
 1. Check the existing [documentation](../)
-2. Look for similar issues in the [issue tracker](https://github.com/blueprint-site/blueprint-site.github.io/issues)
+2. Look for similar issues in the [issue tracker](https://github.com/blueprint-site/blueprint-create/issues)
 3. Join our [Discord server](https://discord.gg/kDa8YC8u5J) for real-time help
-4. Ask in the repository [discussions](https://github.com/blueprint-site/blueprint-site.github.io/discussions)
+4. Ask in the repository [discussions](https://github.com/blueprint-site/blueprint-create/discussions)
 
 ## Next Steps
 

--- a/docs/contributing/index.md
+++ b/docs/contributing/index.md
@@ -26,8 +26,8 @@ Here's a quick overview of the Blueprint contribution process:
 If you need help with contributing:
 
 - **[Join our Discord](https://discord.gg/kDa8YC8u5J)** - Connect with the Blueprint community
-- **[GitHub Discussions](https://github.com/blueprint-site/blueprint-site.github.io/discussions)** - Ask questions and share ideas
-- **[Issue Tracker](https://github.com/blueprint-site/blueprint-site.github.io/issues)** - Report bugs or request features
+- **[GitHub Discussions](https://github.com/blueprint-site/blueprint-create/discussions)** - Ask questions and share ideas
+- **[Issue Tracker](https://github.com/blueprint-site/blueprint-create/issues)** - Report bugs or request features
 
 ## First-Time Contributors
 

--- a/docs/contributing/workflow.md
+++ b/docs/contributing/workflow.md
@@ -20,8 +20,8 @@ Blueprint follows a branch-based workflow for contributions:
 
 1. Clone the repository locally:
    ```bash
-   git clone https://github.com/blueprint-site/blueprint-site.github.io.git
-   cd blueprint-site.github.io
+   git clone https://github.com/blueprint-site/blueprint-create.git
+   cd blueprint-create
    ```
 
 2. Verify your remote:
@@ -122,7 +122,7 @@ If you're working on multiple changes:
 
 ### Creating a Pull Request
 
-1. Go to the [repository](https://github.com/blueprint-site/blueprint-site.github.io)
+1. Go to the [repository](https://github.com/blueprint-site/blueprint-create)
 2. Click "Pull Requests" > "New Pull Request"
 3. Select your branch as the source and `develop` as the target branch
 4. Click "Create Pull Request"
@@ -250,7 +250,7 @@ After your PR is merged:
 
 ### Creating an Issue
 
-1. Navigate to the [Issues page](https://github.com/blueprint-site/blueprint-site.github.io/issues)
+1. Navigate to the [Issues page](https://github.com/blueprint-site/blueprint-create/issues)
 2. Click "New Issue"
 3. Select the appropriate issue template based on the type of issue
 4. Fill out all required fields in the template
@@ -348,6 +348,6 @@ The release process is handled by maintainers, who will:
 If you have questions about contributing:
 
 1. Check the [documentation](../)
-2. Search for existing [issues](https://github.com/blueprint-site/blueprint-site.github.io/issues)
+2. Search for existing [issues](https://github.com/blueprint-site/blueprint-create/issues)
 3. Join our [Discord server](https://discord.gg/kDa8YC8u5J)
-4. Ask in the repository [discussions](https://github.com/blueprint-site/blueprint-site.github.io/discussions)
+4. Ask in the repository [discussions](https://github.com/blueprint-site/blueprint-create/discussions)

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -13,8 +13,8 @@ This guide will walk you through setting up the Blueprint platform for local dev
 1. **Clone the repository**
 
 ```bash
-git clone https://github.com/blueprint-site/blueprint-site.github.io.git
-cd blueprint-site.github.io
+git clone https://github.com/blueprint-site/blueprint-create.git
+cd blueprint-create
 ```
 
 2. **Install dependencies**

--- a/index.html
+++ b/index.html
@@ -12,8 +12,8 @@
     <meta property="og:type" content="website" />
     <meta property="og:title" content="Blueprint" />
     <meta property="og:description" content="Your all in one Create Mod website" />
-    <meta property="og:url" content="https://blueprint-site.github.io/" />
-    <meta property="og:image" content="https://blueprint-site.github.io/static/logo.webp" />
+    <meta property="og:url" content="https://blueprint-create.com/" />
+    <meta property="og:image" content="https://blueprint-create.com/static/logo.webp" />
   </head>
   <script
     defer

--- a/src/api/external/useGithubContributors.ts
+++ b/src/api/external/useGithubContributors.ts
@@ -46,7 +46,7 @@ export function useGitHubContributors() {
 
         // Fetch contributors from both repositories concurrently
         const [frontend, api] = await Promise.all([
-          getContributors('blueprint-site.github.io'),
+          getContributors('blueprint-create'),
           getContributors('blueprint-api'),
         ]);
 

--- a/src/components/features/about/ContactSection.tsx
+++ b/src/components/features/about/ContactSection.tsx
@@ -22,7 +22,7 @@ export function ContactSection() {
           title={t('about.socialsCard.card2.title')}
           badgeName='github-plural'
           description={t('about.socialsCard.card2.description')}
-          link='https://github.com/blueprint-site/blueprint-site.github.io'
+          link='https://github.com/blueprint-site/blueprint-create'
         />
 
         <ContactCard

--- a/src/components/layout/AppFooter.tsx
+++ b/src/components/layout/AppFooter.tsx
@@ -27,7 +27,7 @@ const Footer = ({ className }: FooterProps) => {
             <h6 className='text-xs font-normal'>
               {t('footer.found-bug')}{' '}
               <a
-                href='https://github.com/blueprint-site/blueprint-site.github.io'
+                href='https://github.com/blueprint-site/blueprint-create'
                 className='hover:underline'
               >
                 {t('footer.github-issues')}
@@ -46,7 +46,7 @@ const Footer = ({ className }: FooterProps) => {
                 {t('navigation.label.schematics')}
               </a>
               <a
-                href='https://blueprint-site.github.io/blueprint-blog/'
+                href='https://blueprint-create.com/blueprint-blog/'
                 className='text-xs font-normal hover:underline'
               >
                 {t('navigation.label.blog')}


### PR DESCRIPTION
## Description (required)
Some links that were still pointing to the old github repository and site are updated to new links.
They should now all be updated, WebStorm search shows now old links.
## Testing
I clicked them......They worked

## Related Issues
..Sry forgot to make one... (But I did search I couldn't find an existing one)

## Additional Notes
-

## Screenshots or clips
-
