### PR TITLE
fix(CategorySelectors): Categories can now be selected

### DIFF
--- a/src/components/features/schematics/upload/form/CategorySelectors.tsx
+++ b/src/components/features/schematics/upload/form/CategorySelectors.tsx
@@ -1,5 +1,6 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { Control, UseFormReturn } from 'react-hook-form';
+import { useWatch } from 'react-hook-form';
 import { FormField, FormItem, FormLabel, FormMessage } from '@/components/ui/form';
 import type { SchematicFormValues } from '@/types';
 import type { SchematicSubcategory } from '@/data';
@@ -19,8 +20,8 @@ interface CategorySelectorsProps {
 }
 
 export function CategorySelectors({ control, form }: CategorySelectorsProps) {
-  const formCategories = useMemo(() => form.watch('categories') || [], [form]);
-  const formSubCategories = useMemo(() => form.watch('sub_categories') || [], [form]);
+  const formCategories = useWatch({ control: form.control, name: 'categories' }) || [];
+  const formSubCategories = useWatch({ control: form.control, name: 'sub_categories' }) || [];
   const [selectedCategories, setSelectedCategories] = useState<string[]>(formCategories);
   const [selectedSubCategories, setSelectedSubCategories] = useState<string[]>(formSubCategories);
 


### PR DESCRIPTION
## Description (required)
This fixes the issue of not being able to add categories to blueprints.
I am not an expert with react and webstorm suggests that it can cause performance issues. It suggests I use `useMemo` but with that it didn't work, so if somebody could look into this I would appreciate it.

## Related Issues
Fixes #347 

## Additional Notes
This is my first real time working in react.

## Screenshots or clips
![image](https://github.com/user-attachments/assets/b2c735f6-158a-4f7a-99d5-5a9e8a03a602)

